### PR TITLE
fix: redirect unauthenticated users to signin and fix email confirmat…

### DIFF
--- a/app/(public)/auth/callback-result/page.tsx
+++ b/app/(public)/auth/callback-result/page.tsx
@@ -24,7 +24,23 @@ function AuthCallbackResultContent() {
 
   useEffect(() => {
     const statusParam = searchParams.get("status") as CallbackStatus;
-    if (
+    const successParam = searchParams.get("success");
+    const errorParam = searchParams.get("error");
+
+    // Check for success parameter first
+    if (successParam === "true") {
+      setStatus("success");
+      // Auto-redirect on success
+      setTimeout(() => {
+        router.push("/games");
+      }, 3000);
+    }
+    // Then check for error parameter
+    else if (errorParam) {
+      setStatus("error");
+    }
+    // Then check for status parameter (legacy support)
+    else if (
       statusParam &&
       ["success", "expired", "invalid", "error"].includes(statusParam)
     ) {
@@ -37,7 +53,7 @@ function AuthCallbackResultContent() {
         }, 3000);
       }
     } else {
-      // If no valid status param, default to error
+      // If no valid params, default to error
       setStatus("error");
     }
   }, [searchParams, router]);

--- a/middleware.ts
+++ b/middleware.ts
@@ -36,8 +36,8 @@ export async function middleware(request: NextRequest) {
         // Authenticated users go to /games
         return NextResponse.redirect(new URL("/games", request.url));
       } else {
-        // Unauthenticated users stay on root (home page)
-        return NextResponse.next();
+        // Unauthenticated users go to signin
+        return NextResponse.redirect(new URL("/auth/signin", request.url));
       }
     }
 


### PR DESCRIPTION
…ion callback

- Update middleware to redirect unauthenticated users to /auth/signin instead of showing loading page
- Fix callback-result page to handle success=true parameter from auth callback API
- Maintain backward compatibility with status parameter for legacy support
- Properly handle error parameter for failed confirmations