### PR TITLE
feat: fix OpenGraph sharing for public game detail pages

### DIFF
--- a/app/(private)/games/page.tsx
+++ b/app/(private)/games/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { getAuthenticatedUser } from "@/lib/supabase";
 import { AppHeader, GameSearch } from "@/ui/molecules";
 import { SavedGamesSection } from "@/ui/organisms";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: "Gaming Haven - Your Game Collection",
@@ -38,8 +39,11 @@ export const metadata: Metadata = {
 };
 
 export default async function GamesPage() {
-  await getAuthenticatedUser(); // Ensures user is authenticated
+  const { user, error } = await getAuthenticatedUser();
 
+  if (!user || error) {
+    redirect("/auth/signin");
+  }
   return (
     <div className="px-6 py-8 md:px-12 md:py-16">
       {/* Header - Server Component */}

--- a/app/games/[slug]/_ui/organisms/CollectionButton.tsx
+++ b/app/games/[slug]/_ui/organisms/CollectionButton.tsx
@@ -1,0 +1,21 @@
+import { createSupabaseServerClient } from "@/lib/supabase";
+import { GameCollectionButton } from "@/ui/organisms";
+import { GameFromIGDB } from "@/types/igdb";
+
+// Collection Button component - only renders for authenticated users
+export default async function CollectionButton({
+  gameData,
+}: {
+  gameData: GameFromIGDB;
+}) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  return <GameCollectionButton gameData={gameData} />;
+}

--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -16,8 +16,6 @@ interface GameDetailPageProps {
 
 // AuthenticatedControls component - only renders for authenticated users
 async function AuthenticatedControls() {
-  await getAuthenticatedUser(); // Ensures user is authenticated
-
   return (
     <>
       {/* Back Button and Search - Desktop: same row */}
@@ -125,6 +123,7 @@ export async function generateMetadata({
 
 export default async function GameDetailPage({ params }: GameDetailPageProps) {
   const { slug } = await params;
+  const { user } = await getAuthenticatedUser(); // Ensures user is authenticated
 
   // Get current URL for sharing
   const headersList = await headers();
@@ -174,7 +173,7 @@ export default async function GameDetailPage({ params }: GameDetailPageProps) {
       <div className="relative z-10 px-6 py-8 md:px-12 md:pb-12 md:pt-32">
         <div className="mx-auto max-w-4xl">
           {/* Authenticated Controls: Back Button and Search */}
-          <AuthenticatedControls />
+          {user ? <AuthenticatedControls /> : null}
 
           {/* Game Content - Resolve promise inside JSX */}
           <Suspense fallback={<LoadingSpinner />}>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,7 @@
 import { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://gaming-haven.vercel.app";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL as string;
   const currentDate = new Date();
 
   // Static routes
@@ -24,12 +23,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: currentDate,
       changeFrequency: "monthly",
       priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/games`,
-      lastModified: currentDate,
-      changeFrequency: "daily",
-      priority: 0.9,
     },
     {
       url: `${baseUrl}/games/*`,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { createServerClient } from "@supabase/ssr";
 import { NextRequest, NextResponse } from "next/server";
-import { redirect } from "next/navigation";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
@@ -100,9 +99,5 @@ export const getAuthenticatedUser = async () => {
     error,
   } = await supabase.auth.getUser();
 
-  if (error || !user) {
-    redirect("/auth/signin");
-  }
-
-  return { user, supabase };
+  return { user, error, supabase };
 };


### PR DESCRIPTION
- Refactor middleware to allow public access to game detail pages (/games/[slug])
- Remove aggressive auth checks that were redirecting crawlers to sign-in
- Implement conditional authentication in game detail page component
- Extract CollectionButton to separate component for better organization
- Fix robots.txt and sitemap.xml configuration for proper SEO crawling
- Enable WhatsApp, Facebook, and other social platforms to access OpenGraph metadata
- Maintain security for protected routes while allowing public game detail access
- Preserve user experience for authenticated vs non-authenticated users

The ShareButton now works correctly with proper OpenGraph metadata display when sharing game detail URLs via WhatsApp and other social platforms.